### PR TITLE
Claude/fervent darwin rj9v6

### DIFF
--- a/src/app/brain/page.tsx
+++ b/src/app/brain/page.tsx
@@ -1,6 +1,5 @@
 import { Metadata } from "next";
 import Grid from "@mui/material/Grid";
-import Divider from "@mui/material/Divider";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 import NeurodivergentExperienceDiagram from "@/components/BrainLayout/Experience";
@@ -24,8 +23,10 @@ export const metadata: Metadata = {
 export default function Page() {
 	return (
 		<Box sx={{ flexGrow: 1, p: 4 }}>
-			<Grid container spacing={2} alignItems="flex-start">
-				<Grid container xs={12}>
+			{/* Sections are separated by Grid spacing rather than Dividers so the columns read as
+			    related views of one diagram instead of being chopped apart by hard rules. */}
+			<Grid container spacing={4} alignItems="flex-start">
+				<Grid container item xs={12} spacing={4}>
 					<Grid item xs={12} md={6}>
 						<Typography variant="h5" align="center" gutterBottom>
 							Neurodivergent Experience
@@ -33,17 +34,13 @@ export default function Page() {
 						<NeurodivergentExperienceDiagram />
 					</Grid>
 
-					<Divider orientation="vertical" flexItem sx={{ mx: 2 }} />
-
-					<Grid item xs={12} md={5}>
+					<Grid item xs={12} md={6}>
 						<Typography variant="h5" align="center" gutterBottom>
 							Alexithymia Map
 						</Typography>
 						<AlexithymiaGraph />
 					</Grid>
 				</Grid>
-
-				<Divider orientation="horizontal" flexItem sx={{ mx: 2 }} />
 
 				<Grid item xs={12}>
 					<Typography variant="h5" align="center" gutterBottom>

--- a/src/components/HomeLayout/AgentPromptSuggestions.tsx
+++ b/src/components/HomeLayout/AgentPromptSuggestions.tsx
@@ -33,7 +33,7 @@ export default function AgentPromptSuggestions({ onSelect, disabled }: Props) {
 			<Typography
 				sx={{
 					fontSize: "0.6875rem",
-					fontWeight: 700,
+					fontWeight: 600,
 					letterSpacing: "0.08em",
 					textTransform: "uppercase",
 					color: "text.disabled",

--- a/src/components/HomeLayout/AgentTabs.tsx
+++ b/src/components/HomeLayout/AgentTabs.tsx
@@ -93,8 +93,8 @@ export default function AgentTabs({ tabs, activeId, onSelect, onClose, onCreate,
 
 const barSx: SystemStyleObject<Theme> = {
 	flexShrink: 0,
-	// Use appBg (the outer panel chrome tone) so the tab strip is flush with the
-	// AgentsPanel wrapper below it — no visible seam between the two regions.
+	// Strip container stays on appBg — the same base tone as the AgentsPanel wrapper.
+	// Individual tab pills carry their own surface/transparent fills for contrast.
 	backgroundColor: theme => (theme.palette.mode === "dark" ? TOKENS.dark.appBg : TOKENS.light.appBg),
 	display: "flex",
 	alignItems: "center",
@@ -124,10 +124,11 @@ function tabSx(active: boolean): SystemStyleObject<Theme> {
 		whiteSpace: "nowrap",
 		position: "relative",
 		userSelect: "none",
-		// Match the close button's 120ms timing so hover feels uniform across the tab strip.
 		transition: "background-color 120ms ease, color 120ms ease",
+		// Active tab lifts to the content surface tone so it reads as "open/selected".
+		// Inactive tabs stay transparent so they recede into the strip background.
 		backgroundColor: active
-			? theme => (theme.palette.mode === "dark" ? TOKENS.dark.appBg : TOKENS.light.appBg)
+			? theme => (theme.palette.mode === "dark" ? TOKENS.dark.surface : TOKENS.light.surface)
 			: "transparent",
 		color: active
 			? theme => (theme.palette.mode === "dark" ? TOKENS.dark.textPrimary : TOKENS.light.textPrimary)
@@ -154,8 +155,8 @@ function tabSx(active: boolean): SystemStyleObject<Theme> {
 			backgroundColor: theme =>
 				active
 					? theme.palette.mode === "dark"
-						? TOKENS.dark.appBg
-						: TOKENS.light.appBg
+						? TOKENS.dark.surface
+						: TOKENS.light.surface
 					: theme.palette.mode === "dark"
 						? "rgba(255,255,255,0.04)"
 						: "rgba(0,0,0,0.03)"

--- a/src/components/HomeLayout/AgentTabs.tsx
+++ b/src/components/HomeLayout/AgentTabs.tsx
@@ -93,9 +93,9 @@ export default function AgentTabs({ tabs, activeId, onSelect, onClose, onCreate,
 
 const barSx: SystemStyleObject<Theme> = {
 	flexShrink: 0,
-	// Strip container stays on appBg — the same base tone as the AgentsPanel wrapper.
-	// Individual tab pills carry their own surface/transparent fills for contrast.
-	backgroundColor: theme => (theme.palette.mode === "dark" ? TOKENS.dark.appBg : TOKENS.light.appBg),
+	// Tab strip uses the lighter panel tone. Active tabs use the darker appBg,
+	// so the selected tab "sinks" visually into the panel body below it.
+	backgroundColor: theme => (theme.palette.mode === "dark" ? TOKENS.dark.panel : TOKENS.light.panel),
 	display: "flex",
 	alignItems: "center",
 	height: 33,
@@ -125,10 +125,11 @@ function tabSx(active: boolean): SystemStyleObject<Theme> {
 		position: "relative",
 		userSelect: "none",
 		transition: "background-color 120ms ease, color 120ms ease",
-		// Active tab lifts to the content surface tone so it reads as "open/selected".
-		// Inactive tabs stay transparent so they recede into the strip background.
+		// Active tab is darker (appBg) so it reads as "selected" by sinking into
+		// the panel body below. Inactive tabs are transparent, showing the lighter
+		// panel strip background behind them.
 		backgroundColor: active
-			? theme => (theme.palette.mode === "dark" ? TOKENS.dark.surface : TOKENS.light.surface)
+			? theme => (theme.palette.mode === "dark" ? TOKENS.dark.appBg : TOKENS.light.appBg)
 			: "transparent",
 		color: active
 			? theme => (theme.palette.mode === "dark" ? TOKENS.dark.textPrimary : TOKENS.light.textPrimary)
@@ -155,11 +156,11 @@ function tabSx(active: boolean): SystemStyleObject<Theme> {
 			backgroundColor: theme =>
 				active
 					? theme.palette.mode === "dark"
-						? TOKENS.dark.surface
-						: TOKENS.light.surface
+						? TOKENS.dark.appBg
+						: TOKENS.light.appBg
 					: theme.palette.mode === "dark"
-						? "rgba(255,255,255,0.04)"
-						: "rgba(0,0,0,0.03)"
+						? "rgba(255,255,255,0.06)"
+						: "rgba(0,0,0,0.05)"
 		},
 		"&:focus-visible": {
 			outline: "2px solid",

--- a/src/components/HomeLayout/AgentTabs.tsx
+++ b/src/components/HomeLayout/AgentTabs.tsx
@@ -124,6 +124,8 @@ function tabSx(active: boolean): SystemStyleObject<Theme> {
 		whiteSpace: "nowrap",
 		position: "relative",
 		userSelect: "none",
+		// Match the close button's 120ms timing so hover feels uniform across the tab strip.
+		transition: "background-color 120ms ease, color 120ms ease",
 		backgroundColor: active
 			? theme => (theme.palette.mode === "dark" ? TOKENS.dark.elevated : "#ffffff")
 			: "transparent",

--- a/src/components/HomeLayout/AgentTabs.tsx
+++ b/src/components/HomeLayout/AgentTabs.tsx
@@ -93,7 +93,8 @@ export default function AgentTabs({ tabs, activeId, onSelect, onClose, onCreate,
 
 const barSx: SystemStyleObject<Theme> = {
 	flexShrink: 0,
-	// Share the agents panel base background so the tab strip flows into the header/chat area.
+	// Use appBg (the outer panel chrome tone) so the tab strip is flush with the
+	// AgentsPanel wrapper below it — no visible seam between the two regions.
 	backgroundColor: theme => (theme.palette.mode === "dark" ? TOKENS.dark.appBg : TOKENS.light.appBg),
 	display: "flex",
 	alignItems: "center",
@@ -142,6 +143,12 @@ function tabSx(active: boolean): SystemStyleObject<Theme> {
 					backgroundColor: theme => (theme.palette.mode === "dark" ? TOKENS.dark.accent : TOKENS.light.accent)
 				}
 			: {},
+		...(active && {
+			borderLeft: "1px solid",
+			borderRight: "1px solid",
+			borderColor: theme => (theme.palette.mode === "dark" ? TOKENS.dark.border : TOKENS.light.border),
+			ml: "-1px"
+		}),
 		"&:hover": {
 			color: "text.primary",
 			backgroundColor: theme =>
@@ -233,10 +240,9 @@ const actionButtonSx: SystemStyleObject<Theme> = {
 	borderRadius: "4px",
 	color: theme => (theme.palette.mode === "dark" ? "#c5c5c5" : "#555555"),
 	backgroundColor: "transparent",
-	boxShadow: "none",
 	"&:hover": {
 		color: theme => (theme.palette.mode === "dark" ? "#ffffff" : "#000000"),
 		backgroundColor: theme => (theme.palette.mode === "dark" ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.06)")
 	},
-	"&.Mui-disabled": { opacity: 0.4, backgroundColor: "transparent" }
+	"&.Mui-disabled": { opacity: 0.4 }
 };

--- a/src/components/HomeLayout/AgentTabs.tsx
+++ b/src/components/HomeLayout/AgentTabs.tsx
@@ -93,9 +93,8 @@ export default function AgentTabs({ tabs, activeId, onSelect, onClose, onCreate,
 
 const barSx: SystemStyleObject<Theme> = {
 	flexShrink: 0,
-	// Tab strip uses the chrome/panel tone; the active tab drops to the chat-panel
-	// background so it merges seamlessly into the content below (same as editor tabs).
-	backgroundColor: theme => (theme.palette.mode === "dark" ? TOKENS.dark.panel : TOKENS.light.panel),
+	// Share the agents panel base background so the tab strip flows into the header/chat area.
+	backgroundColor: theme => (theme.palette.mode === "dark" ? TOKENS.dark.appBg : TOKENS.light.appBg),
 	display: "flex",
 	alignItems: "center",
 	height: 33,
@@ -143,12 +142,6 @@ function tabSx(active: boolean): SystemStyleObject<Theme> {
 					backgroundColor: theme => (theme.palette.mode === "dark" ? TOKENS.dark.accent : TOKENS.light.accent)
 				}
 			: {},
-		...(active && {
-			borderLeft: "1px solid",
-			borderRight: "1px solid",
-			borderColor: theme => (theme.palette.mode === "dark" ? TOKENS.dark.border : TOKENS.light.border),
-			ml: "-1px"
-		}),
 		"&:hover": {
 			color: "text.primary",
 			backgroundColor: theme =>
@@ -240,9 +233,10 @@ const actionButtonSx: SystemStyleObject<Theme> = {
 	borderRadius: "4px",
 	color: theme => (theme.palette.mode === "dark" ? "#c5c5c5" : "#555555"),
 	backgroundColor: "transparent",
+	boxShadow: "none",
 	"&:hover": {
 		color: theme => (theme.palette.mode === "dark" ? "#ffffff" : "#000000"),
 		backgroundColor: theme => (theme.palette.mode === "dark" ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.06)")
 	},
-	"&.Mui-disabled": { opacity: 0.4 }
+	"&.Mui-disabled": { opacity: 0.4, backgroundColor: "transparent" }
 };

--- a/src/components/HomeLayout/AgentsPanel.tsx
+++ b/src/components/HomeLayout/AgentsPanel.tsx
@@ -238,7 +238,10 @@ export default function AgentsPanel({ onClose, currentPage, resizable = false }:
 				flexDirection: "column",
 				borderLeft: "1px solid",
 				borderColor: theme => (theme.palette.mode === "dark" ? TOKENS.dark.border : TOKENS.light.border),
-				backgroundColor: theme => (theme.palette.mode === "dark" ? TOKENS.dark.appBg : TOKENS.light.appBg),
+				// Panel body uses the lighter panel tone to match the inactive tab strip,
+				// creating a unified chrome surface. The active tab is darker (appBg) so it
+				// visually "sinks" into the content area below.
+				backgroundColor: theme => (theme.palette.mode === "dark" ? TOKENS.dark.panel : TOKENS.light.panel),
 				overflow: "hidden"
 			}}>
 			{hydrated && (
@@ -253,8 +256,6 @@ export default function AgentsPanel({ onClose, currentPage, resizable = false }:
 				/>
 			)}
 
-			{/* Header sits flush on the same appBg surface as the tab strip and panel body.
-			    No tonal overlay — the text content alone identifies this as the context header. */}
 			<Box sx={{ px: "14px", py: "9px" }}>
 				<Typography sx={{ fontSize: "0.78rem", fontWeight: 600, color: "text.primary", lineHeight: 1.35 }}>
 					Ask about Pratyush&apos;s work

--- a/src/components/HomeLayout/AgentsPanel.tsx
+++ b/src/components/HomeLayout/AgentsPanel.tsx
@@ -237,7 +237,15 @@ export default function AgentsPanel({ onClose, currentPage }: Props) {
 				/>
 			)}
 
-			<Box sx={{ px: "14px", py: "9px", borderBottom: "1px solid", borderColor: "divider" }}>
+			{/* Separated from the chat below by a faint background tone shift rather than a hard
+			    1px rule — the tab strip above already provides a structural border. */}
+			<Box
+				sx={{
+					px: "14px",
+					py: "9px",
+					backgroundColor: theme =>
+						theme.palette.mode === "dark" ? "rgba(255,255,255,0.03)" : "rgba(0,0,0,0.02)"
+				}}>
 				<Typography sx={{ fontSize: "0.78rem", fontWeight: 600, color: "text.primary", lineHeight: 1.35 }}>
 					Ask about Pratyush&apos;s work
 				</Typography>

--- a/src/components/HomeLayout/AgentsPanel.tsx
+++ b/src/components/HomeLayout/AgentsPanel.tsx
@@ -253,15 +253,9 @@ export default function AgentsPanel({ onClose, currentPage, resizable = false }:
 				/>
 			)}
 
-			{/* Header reads as its own band via a faint background tone shift rather than a hard
-			    1px rule, keeping the seamless flow from the tab strip into the chat below. */}
-			<Box
-				sx={{
-					px: "14px",
-					py: "9px",
-					backgroundColor: theme =>
-						theme.palette.mode === "dark" ? "rgba(255,255,255,0.03)" : "rgba(0,0,0,0.02)"
-				}}>
+			{/* Header sits flush on the same appBg surface as the tab strip and panel body.
+			    No tonal overlay — the text content alone identifies this as the context header. */}
+			<Box sx={{ px: "14px", py: "9px" }}>
 				<Typography sx={{ fontSize: "0.78rem", fontWeight: 600, color: "text.primary", lineHeight: 1.35 }}>
 					Ask about Pratyush&apos;s work
 				</Typography>

--- a/src/components/HomeLayout/AgentsPanel.tsx
+++ b/src/components/HomeLayout/AgentsPanel.tsx
@@ -238,10 +238,7 @@ export default function AgentsPanel({ onClose, currentPage, resizable = false }:
 				flexDirection: "column",
 				borderLeft: "1px solid",
 				borderColor: theme => (theme.palette.mode === "dark" ? TOKENS.dark.border : TOKENS.light.border),
-				// Panel body uses the lighter panel tone to match the inactive tab strip,
-				// creating a unified chrome surface. The active tab is darker (appBg) so it
-				// visually "sinks" into the content area below.
-				backgroundColor: theme => (theme.palette.mode === "dark" ? TOKENS.dark.panel : TOKENS.light.panel),
+				backgroundColor: theme => (theme.palette.mode === "dark" ? TOKENS.dark.appBg : TOKENS.light.appBg),
 				overflow: "hidden"
 			}}>
 			{hydrated && (

--- a/src/components/HomeLayout/ExplorerPanel.tsx
+++ b/src/components/HomeLayout/ExplorerPanel.tsx
@@ -118,7 +118,7 @@ function Section({
 					<Typography
 						sx={{
 							fontSize: "11px",
-							fontWeight: 700,
+							fontWeight: 600,
 							textTransform: "uppercase",
 							letterSpacing: "0.08em",
 							color: dark ? "#d4d4d4" : "#555555",

--- a/src/components/HomeLayout/ExplorerPanel.tsx
+++ b/src/components/HomeLayout/ExplorerPanel.tsx
@@ -22,6 +22,7 @@ import ResizeHandle from "./ResizeHandle";
 import { Page } from "@/types";
 import { slugifyHeading } from "@/utils/markdownAnchors";
 import { useResizableWidth } from "@/utils/useResizableWidth";
+import { TOKENS } from "@/ui/Theme";
 
 const MIN_WIDTH = 200;
 const MAX_WIDTH = 480;
@@ -185,7 +186,8 @@ export default function ExplorerPanel({
 		side: "right"
 	});
 
-	const sidebarBg = dark ? "#1e1e1e" : "#f3f3f3";
+	// Mirror the agents panel: side panels share appBg so both recede behind the editor surface.
+	const sidebarBg = dark ? TOKENS.dark.appBg : "#f3f3f3";
 	const borderStyle = dark ? "1px solid #3a3a3a" : `1px solid ${theme.palette.divider}`;
 	const iconActive = dark ? "#ffffff" : "#333333";
 	const iconActiveBg = dark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.04)";
@@ -215,7 +217,9 @@ export default function ExplorerPanel({
 				sx={{
 					display: "flex",
 					alignItems: "center",
-					height: "35px",
+					// Match the editor tab strip (AppButtons) / agent tab strip height so the
+					// sidebar's first row lines up with the editor tabs across the workspace.
+					height: "33px",
 					px: "8px",
 					gap: "2px",
 					borderBottom: borderStyle,

--- a/src/components/HomeLayout/ExplorerPanel.tsx
+++ b/src/components/HomeLayout/ExplorerPanel.tsx
@@ -187,7 +187,7 @@ export default function ExplorerPanel({
 	});
 
 	// Mirror the agents panel: side panels share appBg so both recede behind the editor surface.
-	const sidebarBg = dark ? TOKENS.dark.appBg : "#f3f3f3";
+	const sidebarBg = dark ? TOKENS.dark.appBg : TOKENS.light.appBg;
 	const borderStyle = dark ? "1px solid #3a3a3a" : `1px solid ${theme.palette.divider}`;
 	const iconActive = dark ? "#ffffff" : "#333333";
 	const iconActiveBg = dark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.04)";

--- a/src/components/HomeLayout/TopCommandBar.tsx
+++ b/src/components/HomeLayout/TopCommandBar.tsx
@@ -138,53 +138,66 @@ export default function TopCommandBar({
 				borderBottom: darkMode ? "1px solid #3a3a3a" : "1px solid #e5e5e5",
 				backgroundColor: darkMode ? "#252526" : "#f3f3f3"
 			}}>
-			<Tooltip title={explorerOpen ? "Hide explorer" : "Show explorer"} arrow>
-				<IconButton
-					size="small"
-					onClick={onExplorerToggle}
-					aria-label={explorerOpen ? "Hide explorer" : "Show explorer"}
-					aria-pressed={explorerOpen}
-					sx={iconButtonSx}>
-					<LuPanelLeft size={18} />
-				</IconButton>
-			</Tooltip>
+			{/* Left + right clusters carry equal flex weight, so the fixed-width search box
+			    between them stays locked to the bar's center regardless of the (variable-length)
+			    title / page name. */}
+			<Box sx={{ flex: 1, minWidth: 0, display: "flex", alignItems: "center", gap: 1 }}>
+				<Tooltip title={explorerOpen ? "Hide explorer" : "Show explorer"} arrow>
+					<IconButton
+						size="small"
+						onClick={onExplorerToggle}
+						aria-label={explorerOpen ? "Hide explorer" : "Show explorer"}
+						aria-pressed={explorerOpen}
+						sx={iconButtonSx}>
+						<LuPanelLeft size={18} />
+					</IconButton>
+				</Tooltip>
 
-			<Box sx={{ display: "flex", alignItems: "center", gap: "6px", minWidth: 0 }}>
-				<Typography
-					sx={{
-						fontSize: "13px",
-						fontWeight: 400,
-						color: darkMode ? "#e0e0e0" : "#333333",
-						whiteSpace: "nowrap",
-						lineHeight: 1
-					}}>
-					Pratyush Sudhakar
-				</Typography>
-				<Typography
-					sx={{
-						fontSize: "13px",
-						fontWeight: 400,
-						color: darkMode ? "#a8a8a8" : "#5d5d5d",
-						whiteSpace: "nowrap",
-						lineHeight: 1,
-						display: { xs: "none", sm: "block" }
-					}}>
-					/ Portfolio Workspace
-				</Typography>
-				<Typography
-					sx={{
-						fontSize: "13px",
-						fontWeight: 400,
-						color: darkMode ? "#a8a8a8" : "#5d5d5d",
-						whiteSpace: "nowrap",
-						lineHeight: 1,
-						display: { xs: "none", md: "block" }
-					}}>
-					- {currentPage}
-				</Typography>
+				<Box sx={{ display: "flex", alignItems: "center", gap: "6px", minWidth: 0 }}>
+					<Typography
+						sx={{
+							fontSize: "13px",
+							fontWeight: 400,
+							color: darkMode ? "#e0e0e0" : "#333333",
+							whiteSpace: "nowrap",
+							lineHeight: 1
+						}}>
+						Pratyush Sudhakar
+					</Typography>
+					<Typography
+						sx={{
+							fontSize: "13px",
+							fontWeight: 400,
+							color: darkMode ? "#a8a8a8" : "#5d5d5d",
+							whiteSpace: "nowrap",
+							lineHeight: 1,
+							display: { xs: "none", sm: "block" }
+						}}>
+						/ Portfolio Workspace
+					</Typography>
+					<Typography
+						sx={{
+							fontSize: "13px",
+							fontWeight: 400,
+							color: darkMode ? "#a8a8a8" : "#5d5d5d",
+							whiteSpace: "nowrap",
+							lineHeight: 1,
+							display: { xs: "none", md: "block" }
+						}}>
+						- {currentPage}
+					</Typography>
+				</Box>
 			</Box>
 
-			<Box sx={{ flex: 1, display: { xs: "none", sm: "flex" }, justifyContent: "center", px: 2 }}>
+			{/* Center search: fixed flex basis with no grow, so it never reflows when the
+			    title cluster changes width. */}
+			<Box
+				sx={{
+					flex: "0 1 460px",
+					maxWidth: 460,
+					display: { xs: "none", sm: "flex" },
+					justifyContent: "center"
+				}}>
 				<ClickAwayListener onClickAway={() => setOpen(false)}>
 					<Box
 						component="form"
@@ -316,7 +329,16 @@ export default function TopCommandBar({
 				</ClickAwayListener>
 			</Box>
 
-			<Box sx={{ display: "flex", alignItems: "center", gap: 0.25, ml: "auto" }}>
+			{/* Right cluster: equal flex weight to the left cluster keeps the search centered. */}
+			<Box
+				sx={{
+					flex: 1,
+					minWidth: 0,
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "flex-end",
+					gap: 0.25
+				}}>
 				{resume && (
 					<Button
 						component={Link}

--- a/src/ui/Theme.tsx
+++ b/src/ui/Theme.tsx
@@ -5,9 +5,9 @@ import { createTheme, darkScrollbar } from "@mui/material";
 // touching individual components. Values mirror Cursor's default dark theme exactly.
 export const TOKENS = {
 	dark: {
-		appBg: "#1e1e1e", // outer window shell background
+		appBg: "#181818", // outer window shell + side panels (explorer/agents); sits darker than the editor
 		panel: "#252526", // elevated panels - toolbar, tab strip, search dropdown
-		surface: "#1e1e1e", // editor content surface (active tab + scroll area)
+		surface: "#1e1e1e", // editor content surface (active tab + scroll area); lighter than the side panels
 		elevated: "#2d2d2d", // hover / raised state
 		border: "#3a3a3a", // universal divider between regions
 		textPrimary: "#cccccc",

--- a/src/ui/Theme.tsx
+++ b/src/ui/Theme.tsx
@@ -74,7 +74,10 @@ export default function theme(darkMode: boolean, paletteOverrides?: any) {
 			styleOverrides: {
 				root: {
 					color: t.textPrimary,
-					backgroundColor: t.surface,
+					// Use transparent so icon buttons in sidebar panel headers (explorer toolbar,
+					// agent tab strip, etc.) don't inherit a raised surface background that boxes
+					// them in. Active/selected backgrounds are applied per-component via inline sx.
+					backgroundColor: "transparent",
 					"&:hover": { backgroundColor: t.elevated },
 					"@media (max-width:600px)": { padding: "4px" }
 				}


### PR DESCRIPTION
# Summary

This PR fixes #issue_number.

# Description

The approach taken to fix this issue was to...

# Notes/Considerations

-   [ ] Tests
-   [ ] Documentation

# Screenshots (if applicable)

This PR changes the following pages:

-   Page 1 <img src='' />
-   Page 2 <img src='' />

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR is a design-token and layout polish pass across the home workspace UI. It moves side-panel background colors from hardcoded hex values to `TOKENS`, restructures `TopCommandBar` so the search box stays centered, deepens the dark-mode `appBg` to `#181818` for a clearer surface hierarchy, and cleans up the brain page layout by replacing `Divider` components with Grid spacing.

- **Theme tokens (`src/ui/Theme.tsx`)**: `dark.appBg` darkens from `#1e1e1e` → `#181818` so side panels recede behind the editor surface, and `MuiIconButton` now defaults to `transparent` background instead of `t.surface`.
- **Side panels (`ExplorerPanel`, `AgentsPanel`, `AgentTabs`)**: Backgrounds and heights are now driven by `TOKENS`, toolbar height trimmed to 33 px to align with the agent tab strip, and tab transitions added for smoother active-state feedback.
- **TopCommandBar**: Refactored to a three-column flex layout (left cluster · center search · right cluster) that keeps the search box visually centered regardless of the title text width.
</details>

<h3>Confidence Score: 5/5</h3>

All changes are cosmetic — token values, flex layout, and spacing — with no data handling or logic alterations. Safe to merge.

Every change touches only visual styling: background colors, font weights, padding, and layout structure. No business logic, data flow, or API interactions are affected.

No files require special attention beyond the minor color-token inconsistency in TopCommandBar.tsx.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/ui/Theme.tsx | Changes dark.appBg from #1e1e1e to #181818 to create depth contrast vs. the editor surface, and switches MuiIconButton global background from t.surface to transparent so sidebar toolbar icons don't render a raised box behind them. |
| src/components/HomeLayout/TopCommandBar.tsx | Restructures the bar into three flex children for a locked-center search box; the hardcoded light-mode backgroundColor: "#f3f3f3" now diverges from TOKENS.light.panel (#f8f8f8) which the refactored side panels use. |
| src/components/HomeLayout/ExplorerPanel.tsx | Replaces hardcoded sidebar background colors with TOKENS.dark.appBg / TOKENS.light.appBg for token-based consistency with the agents panel, and trims the toolbar row from 35 px to 33 px to align with the agent tab strip height. |
| src/components/HomeLayout/AgentTabs.tsx | Adds a 120 ms background-color / color transition to tabs and bumps inactive-tab hover opacity from 0.04/0.03 to 0.06/0.05 for better affordance. |
| src/components/HomeLayout/AgentsPanel.tsx | Removes the borderBottom separator between the agent tab strip and the header — a deliberate design decision to reduce visual clutter. |
| src/components/HomeLayout/AgentPromptSuggestions.tsx | Tones label fontWeight from 700 to 600 for a slightly lighter all-caps label appearance. |
| src/app/brain/page.tsx | Removes vertical/horizontal Divider components in favour of Grid spacing, adds the missing item prop to the inner grid container, and balances both diagram columns to md=6. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TopCommandBar] --> B[Left cluster flex:1]
    A --> C[Center search flex:0 1 460px]
    A --> D[Right cluster flex:1]
    E[ExplorerPanel TOKENS.appBg] --> F[dark:#181818 / light:#f8f8f8]
    G[AgentsPanel TOKENS.appBg] --> F
    H[AgentTabs] --> I[active: TOKENS.appBg]
    H --> J[inactive: transparent + transition 120ms]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcomponents%2FHomeLayout%2FTopCommandBar.tsx%3A139%0A**Hardcoded%20%60%23f3f3f3%60%20diverges%20from%20design%20tokens%20in%20light%20mode**%0A%0AThe%20command%20bar's%20light-mode%20%60backgroundColor%60%20is%20still%20%60%22%23f3f3f3%22%60%2C%20but%20this%20PR%20moved%20the%20Explorer%20and%20Agents%20panels%20to%20%60TOKENS.light.appBg%60%20%2F%20%60TOKENS.light.panel%60%20%28both%20%60%22%23f8f8f8%22%60%29.%20The%20values%20are%20close%20but%20not%20equal%2C%20so%20the%20toolbar%20will%20render%20a%20slightly%20different%20background%20shade%20from%20the%20side%20panels%20in%20light%20mode.%20Consider%20replacing%20with%20%60TOKENS.light.panel%60%20%28and%20%60TOKENS.dark.panel%60%20for%20dark%20mode%2C%20which%20already%20matches%20%60%22%23252526%22%60%29.%0A%0A&pr=18&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pratyush1712%2Fpersonal-website%22%20on%20the%20existing%20branch%20%22claude%2Ffervent-darwin-Rj9v6%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Ffervent-darwin-Rj9v6%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcomponents%2FHomeLayout%2FTopCommandBar.tsx%3A139%0A**Hardcoded%20%60%23f3f3f3%60%20diverges%20from%20design%20tokens%20in%20light%20mode**%0A%0AThe%20command%20bar's%20light-mode%20%60backgroundColor%60%20is%20still%20%60%22%23f3f3f3%22%60%2C%20but%20this%20PR%20moved%20the%20Explorer%20and%20Agents%20panels%20to%20%60TOKENS.light.appBg%60%20%2F%20%60TOKENS.light.panel%60%20%28both%20%60%22%23f8f8f8%22%60%29.%20The%20values%20are%20close%20but%20not%20equal%2C%20so%20the%20toolbar%20will%20render%20a%20slightly%20different%20background%20shade%20from%20the%20side%20panels%20in%20light%20mode.%20Consider%20replacing%20with%20%60TOKENS.light.panel%60%20%28and%20%60TOKENS.dark.panel%60%20for%20dark%20mode%2C%20which%20already%20matches%20%60%22%23252526%22%60%29.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcomponents%2FHomeLayout%2FTopCommandBar.tsx%3A139%0A**Hardcoded%20%60%23f3f3f3%60%20diverges%20from%20design%20tokens%20in%20light%20mode**%0A%0AThe%20command%20bar's%20light-mode%20%60backgroundColor%60%20is%20still%20%60%22%23f3f3f3%22%60%2C%20but%20this%20PR%20moved%20the%20Explorer%20and%20Agents%20panels%20to%20%60TOKENS.light.appBg%60%20%2F%20%60TOKENS.light.panel%60%20%28both%20%60%22%23f8f8f8%22%60%29.%20The%20values%20are%20close%20but%20not%20equal%2C%20so%20the%20toolbar%20will%20render%20a%20slightly%20different%20background%20shade%20from%20the%20side%20panels%20in%20light%20mode.%20Consider%20replacing%20with%20%60TOKENS.light.panel%60%20%28and%20%60TOKENS.dark.panel%60%20for%20dark%20mode%2C%20which%20already%20matches%20%60%22%23252526%22%60%29.%0A%0A&repo=pratyush1712%2Fpersonal-website&pr=18&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/components/HomeLayout/TopCommandBar.tsx:139
**Hardcoded `#f3f3f3` diverges from design tokens in light mode**

The command bar's light-mode `backgroundColor` is still `"#f3f3f3"`, but this PR moved the Explorer and Agents panels to `TOKENS.light.appBg` / `TOKENS.light.panel` (both `"#f8f8f8"`). The values are close but not equal, so the toolbar will render a slightly different background shade from the side panels in light mode. Consider replacing with `TOKENS.light.panel` (and `TOKENS.dark.panel` for dark mode, which already matches `"#252526"`).

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["Change background color in AgentsPanel c..."](https://github.com/pratyush1712/personal-website/commit/8fe051e30079cd22502dc656dcc587a31365bc4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35085014)</sub>

<!-- /greptile_comment -->